### PR TITLE
Add final newline in py → ipynb conversion

### DIFF
--- a/colab_convert/__main__.py
+++ b/colab_convert/__main__.py
@@ -519,6 +519,7 @@ def convert(in_file, out_file, extra_flags):
         notebook = py2nb(py_str, extra_flags)
         with open(out_file, 'w', encoding='utf-8') as f:
             json.dump(notebook, f, indent=2)
+            f.write("\n")
 
     else:
         logging.critical(translation['defmsg_file_ext_msg'])


### PR DESCRIPTION
Python json package doesn't add the final newline. Therefore we add it manually. This is useful to avoid the "Missing final new line error" of many linting tools and the GitHub warning.